### PR TITLE
nix: Add Nix Package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743095683,
+        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "IncusScripts CLI";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    supportedSystems = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+  in {
+    packages = forAllSystems (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        scripts-cli = pkgs.callPackage ./nix/package.nix {};
+        default = self.packages.${system}.scripts-cli;
+      }
+    );
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGo123Module,
+  installShellFiles,
+}:
+buildGo123Module rec {
+  pname = "scripts-cli";
+  version = "latest";
+
+  src = ./../cli;
+
+  vendorHash = "sha256-iPxabKi33tJH8xQ9gPr9XmT0LcBwxtonnXJlJMnYxjw=";
+  subPackages = ["." "./cmd"];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = ''
+    # Rename the binary from cli to scripts-cli
+    mv $out/bin/cmd $out/bin/scripts-cli
+
+    installShellCompletion --cmd scripts-cli \
+          --bash <($out/bin/scripts-cli completion bash) \
+          --fish <($out/bin/scripts-cli completion fish) \
+          --zsh <($out/bin/scripts-cli completion zsh)
+  '';
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-X github.com/bketelsen/IncusScripts/cli/cmd/main.commit=${version}"
+  ];
+
+  meta = {
+    description = "Incus Helper-Scripts";
+    homepage = "https://github.com/bketelsen/IncusScripts";
+    license = lib.licenses.mit;
+    mainProgram = "scripts-cli";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## ✍️ Description
Similarly to my PR on your other project `incus-compose`, this adds a Nix package for the IncusScripts CLI to let it be used on systems using the Nix package manager. 

I tested this and it seems to work. Some scripts failed (caddy, npmplus, and searxng) however I think that's an issue with the scripts and not this package.

 

- - -
- Related Issue: N/A
- Related PR: N/A
- Related Discussion: N/A
- - - 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

